### PR TITLE
Fix RetrievalMetrics component

### DIFF
--- a/frontend/src/views/EvaluationView.vue
+++ b/frontend/src/views/EvaluationView.vue
@@ -131,7 +131,7 @@
 <script>
 import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import RetrievalMetrics from '@/components/RetrievalMetrics.vue'
+import RetrievalMetrics from '../components/RetrievalMetrics.vue'
 
 export default {
   name: 'EvaluationView',


### PR DESCRIPTION
The `RetrievalMetrics` component cannot be found:

```
[vite]: Rollup failed to resolve import "@/components/RetrievalMetrics.vue" from "/home/aorth/src/git/containerized-rag-starter-kit/frontend/src/views/EvaluationView.vue".
```