### PR TITLE
api_service: use doi.org instead of dx.doi.org

### DIFF
--- a/api_service/services/query_service.py
+++ b/api_service/services/query_service.py
@@ -96,7 +96,7 @@ class QueryService:
                     references.append(doc['reference'])
                 # Priority 2: Use DOI link if available
                 elif doc.get('doi'):
-                    references.append(f"https://dx.doi.org/{doc['doi']}")
+                    references.append(f"https://doi.org/{doc['doi']}")
                 # No fallback to filename - skip if no citation or DOI
         
         return references
@@ -156,7 +156,7 @@ class QueryService:
                 if document_id in documents_by_id:
                     doc = documents_by_id[document_id]
                     if doc.get('doi'):
-                        references.append(f"https://dx.doi.org/{doc['doi']}")
+                        references.append(f"https://doi.org/{doc['doi']}")
         # else:
         #     # Non-academic mode: Try to get DOI links from document table
         #     references = []
@@ -181,7 +181,7 @@ class QueryService:
         #         if document_id in documents_by_id:
         #             doc = documents_by_id[document_id]
         #             if doc.get('doi'):
-        #                 references.append(f"https://dx.doi.org/{doc['doi']}")
+        #                 references.append(f"https://doi.org/{doc['doi']}")
         
         # Generate answer with OpenAI
         prompt = f"""

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -163,7 +163,7 @@ export default {
     }
     
     const openDoi = (doi) => {
-      const url = doi.startsWith('http') ? doi : `https://dx.doi.org/${doi}`
+      const url = doi.startsWith('http') ? doi : `https://doi.org/${doi}`
       window.open(url, '_blank')
     }
     


### PR DESCRIPTION
dx.doi.org is a legacy domain (will be maintained "forever", but it is recommended to use doi.org now).

See [Crossref's DOI display guidelines](https://www.crossref.org/display-guidelines/).